### PR TITLE
another mapDispatchToProps with bindActionCreators

### DIFF
--- a/src/snippets/redux.json
+++ b/src/snippets/redux.json
@@ -76,7 +76,7 @@
 		"prefix": "mapDispatchToProps",
 		"body": [
 			"const mapDispatchToProps = (dispatch) => ({",
-			"\t...bindActionCreators(actions, dispatch),",
+			"\t...bindActionCreators(${actionCreators}, dispatch),",
 			"});",
 			""
 		],

--- a/src/snippets/redux.json
+++ b/src/snippets/redux.json
@@ -72,6 +72,16 @@
 		],
 		"description": "A Redux mapDispatchToProps function"
 	},
+	"Redux mapDispatchToProps + bindActionCreators function": {
+		"prefix": "mapDispatchToProps",
+		"body": [
+			"const mapDispatchToProps = (dispatch) => ({",
+			"\t...bindActionCreators(actions, dispatch),",
+			"});",
+			""
+		],
+		"description": "A Redux mapDispatchToProps + bindActionCreators function"
+	},
 	"Redux mergeProps function": {
 		"prefix": "mergeProps",
 		"body": [


### PR DESCRIPTION
Another version of mapDispatchToProps with bindActionCreators for a shorter form:

```
const mapDispatchToProps = (dispatch) => ({
  ...bindActionCreators(actions, dispatch),
});
```
